### PR TITLE
Add register user API endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,11 @@ gem 'puma'
 gem 'rails', '~> 6.1.3'
 
 # API development
+gem 'dry-validation'
 gem 'grape'
 gem 'grape-swagger'
 gem 'grape-swagger-rails'
+gem 'jsonapi-serializer'
 gem 'rack-cors'
 
 # Authentication
@@ -38,4 +40,8 @@ end
 group :development do
   gem 'listen', '~> 3.3'
   gem 'spring'
+end
+
+group :test do
+  gem 'shoulda-matchers'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'grape'
 gem 'grape-swagger'
 gem 'grape-swagger-rails'
 gem 'jsonapi-serializer'
+gem 'pundit'
 gem 'rack-cors'
 
 # Authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,16 +89,32 @@ GEM
       dry-configurable (~> 0.1, >= 0.1.3)
     dry-core (0.5.0)
       concurrent-ruby (~> 1.0)
+    dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
+    dry-initializer (3.0.4)
     dry-logic (1.1.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
+    dry-schema (1.6.1)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.8, >= 0.8.3)
+      dry-core (~> 0.5, >= 0.5)
+      dry-initializer (~> 3.0)
+      dry-logic (~> 1.0)
+      dry-types (~> 1.5)
     dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
+    dry-validation (1.6.0)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.7, >= 0.7.1)
+      dry-core (~> 0.4)
+      dry-equalizer (~> 0.2)
+      dry-initializer (~> 3.0)
+      dry-schema (~> 1.5, >= 1.5.2)
     erubi (1.10.0)
     ffi (1.14.2)
     globalid (0.4.2)
@@ -116,6 +132,8 @@ GEM
       railties (>= 3.2.12)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    jsonapi-serializer (2.1.0)
+      activesupport (>= 4.2)
     jwt (2.2.2)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -233,6 +251,8 @@ GEM
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -265,9 +285,11 @@ DEPENDENCIES
   byebug
   devise
   devise-jwt
+  dry-validation
   grape
   grape-swagger
   grape-swagger-rails
+  jsonapi-serializer
   listen (~> 3.3)
   pg (~> 1.1)
   pry-byebug
@@ -278,6 +300,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rspec
+  shoulda-matchers
   spring
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
       pry (>= 0.10.4)
     puma (5.2.1)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-accept (0.4.5)
@@ -295,6 +297,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
+  pundit
   rack-cors
   rails (~> 6.1.3)
   rspec-rails

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -2,9 +2,13 @@
 
 module API
   class Base < Grape::API
+    include Rescuers
+
     after { verify_authorized }
 
     helpers Helpers::AuthHelper
+    helpers Helpers::ErrorHelper
+
     add_swagger_documentation(
       mount_path: '/docs',
       array_use_braces: true,

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -4,10 +4,11 @@ module API
   class Base < Grape::API
     include Rescuers
 
-    after { verify_authorized }
-
     helpers Helpers::AuthHelper
     helpers Helpers::ErrorHelper
+    helpers Helpers::PermittedParamsHelper
+
+    mount V1::Base
 
     add_swagger_documentation(
       mount_path: '/docs',

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -2,6 +2,7 @@
 
 module API
   class Base < Grape::API
+    helpers Helpers::AuthHelper
     add_swagger_documentation(
       mount_path: '/docs',
       array_use_braces: true,

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -2,6 +2,8 @@
 
 module API
   class Base < Grape::API
+    after { verify_authorized }
+
     helpers Helpers::AuthHelper
     add_swagger_documentation(
       mount_path: '/docs',

--- a/app/controllers/api/helpers/auth_helper.rb
+++ b/app/controllers/api/helpers/auth_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module API
+  module Helpers
+    module AuthHelper
+      extend ::Grape::API::Helpers
+      include Pundit
+
+      def current_user
+        warden = env['warden']
+        @current_user ||= warden.authenticate
+      end
+
+      def authenticate_user!
+        raise UnauthenticatedError unless current_user.present?
+      end
+    end
+  end
+end

--- a/app/controllers/api/helpers/auth_helper.rb
+++ b/app/controllers/api/helpers/auth_helper.rb
@@ -2,6 +2,8 @@
 
 module API
   module Helpers
+    # Includes some helper methods allowing Grape to integrate with authentication system (Devise + Warden)
+    # and authorization system (Pundit)
     module AuthHelper
       extend ::Grape::API::Helpers
       include Pundit

--- a/app/controllers/api/helpers/error_helper.rb
+++ b/app/controllers/api/helpers/error_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module API
+  module Helpers
+    module ErrorHelper
+      extend ::Grape::API::Helpers
+
+      def render_json_api_error(status:, title:, description:)
+        error!(
+          {
+            errors: [{
+              status: status,
+              title: title,
+              description: description
+            }]
+          },
+          status
+        )
+      end
+
+      def validation_error_description(error)
+        error.validation_errors
+      end
+
+      def not_found_description(error)
+        "Could not found #{error.model.underscore.humanize.downcase}"
+      end
+    end
+  end
+end

--- a/app/controllers/api/helpers/error_helper.rb
+++ b/app/controllers/api/helpers/error_helper.rb
@@ -2,6 +2,8 @@
 
 module API
   module Helpers
+    # Includes some basic methods used for proper representation of app-level exceptions
+    # in a form of HTTP errors with JSON API compliant format
     module ErrorHelper
       extend ::Grape::API::Helpers
 

--- a/app/controllers/api/helpers/permitted_params_helper.rb
+++ b/app/controllers/api/helpers/permitted_params_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module API
+  module Helpers
+    # Provides simple method to fetch only declared and passed params
+    module PermittedParamsHelper
+      extend ::Grape::API::Helpers
+
+      def permitted_params
+        declared(params, include_missing: false)
+      end
+    end
+  end
+end

--- a/app/controllers/api/rescuers.rb
+++ b/app/controllers/api/rescuers.rb
@@ -38,7 +38,7 @@ module API
       end
 
       rescue_from :all do
-        render_jsonapi_errors(
+        render_json_api_error(
           status: 500,
           title: 'Internal server error',
           description: 'Something went wrong, please try again later'

--- a/app/controllers/api/rescuers.rb
+++ b/app/controllers/api/rescuers.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module API
+  module Rescuers
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from UnauthenticatedError do
+        render_json_api_error(
+          status: 401,
+          title: 'Not authenticated',
+          description: 'Not authenticated, authenticate and try again'
+        )
+      end
+
+      rescue_from Pundit::NotAuthorizedError do
+        render_json_api_error(
+          status: 403,
+          title: 'Not authorized',
+          description: 'You are not authorized to perform this action'
+        )
+      end
+
+      rescue_from ActiveRecord::RecordNotFound do |error|
+        render_json_api_error(
+          status: 404,
+          title: 'Record Not Found',
+          description: not_found_description(error)
+        )
+      end
+
+      rescue_from ValidationError do |error|
+        render_json_api_error(
+          status: 422,
+          title: 'Invalid payload',
+          description: validation_error_description(error)
+        )
+      end
+
+      rescue_from :all do
+        render_jsonapi_errors(
+          status: 500,
+          title: 'Internal server error',
+          description: 'Something went wrong, please try again later'
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base.rb
+++ b/app/controllers/api/v1/base.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    class Base < Grape::API
+      version 'v1', using: :path
+
+      content_type :json, 'application/vnd.api+json'
+      default_format :json
+
+      # Verify Pundit policy was called (or skip_authorization was called explicitly)
+      after { verify_authorized }
+
+      mount CinemaWorkers::Base
+      mount Users::Base
+    end
+  end
+end

--- a/app/controllers/api/v1/cinema_workers/base.rb
+++ b/app/controllers/api/v1/cinema_workers/base.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    module CinemaWorkers
+      class Base < Grape::API
+        namespace :cinema_workers do
+          before { authenticate_user! }
+
+          mount Create
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/cinema_workers/create.rb
+++ b/app/controllers/api/v1/cinema_workers/create.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    module CinemaWorkers
+      class Create < Grape::API
+        desc '[Cinema worker only] Create a new cinema worker',
+             success: { code: 201, message: 'Cinema worker created successfully' },
+             failure: [
+               { code: 401, message: 'User is not authenticated' },
+               { code: 403, message: 'User is not authorized to create a cinema worker' },
+               { code: 422, message: 'Invalid params' }
+             ]
+
+        params do
+          requires :first_name, type: String
+          requires :last_name, type: String
+          requires :email, type: String
+          requires :password, type: String
+          requires :password_confirmation, type: String
+        end
+
+        post do
+          authorize User, :create?, policy_class: CinemaWorkersPolicy
+
+          ::Users::CreateValidator.new.validate(permitted_params)
+
+          UserSerializer.new(
+            User.create!(permitted_params.merge(is_cinema_worker: true))
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/base.rb
+++ b/app/controllers/api/v1/users/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    module Users
+      class Base < Grape::API
+        namespace :users do
+          mount Create
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users/create.rb
+++ b/app/controllers/api/v1/users/create.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    module Users
+      class Create < Grape::API
+        desc 'Create a new user',
+             success: { code: 201, message: 'User created successfully' },
+             failure: [
+               { code: 422, message: 'Invalid params' }
+             ]
+
+        params do
+          requires :first_name, type: String
+          requires :last_name, type: String
+          requires :email, type: String
+          requires :password, type: String
+          requires :password_confirmation, type: String
+        end
+
+        post do
+          skip_authorization
+
+          ::Users::CreateValidator.new.validate(permitted_params)
+
+          UserSerializer.new(
+            User.create!(permitted_params.merge(is_cinema_worker: false))
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/errors/unauthenticated_error.rb
+++ b/app/errors/unauthenticated_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UnauthenticatedError < StandardError
+end

--- a/app/errors/validation_error.rb
+++ b/app/errors/validation_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ValidationError < StandardError
+  attr_reader :validation_errors
+
+  def initialize(validation_errors)
+    @validation_errors = validation_errors
+    super('Validation failed')
+  end
+end

--- a/app/models/allowlisted_jwt.rb
+++ b/app/models/allowlisted_jwt.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class AllowlistedJwt < ApplicationRecord
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/concerns/user_roles.rb
+++ b/app/models/concerns/user_roles.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module UserRoles
+  CINEMA_WORKER = 'cinema_worker'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
          :recoverable,
          :jwt_authenticatable,
          jwt_revocation_strategy: self
+
+  def role?(name)
+    name == UserRoles::CINEMA_WORKER ? is_cinema_worker : false
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/cinema_workers_policy.rb
+++ b/app/policies/cinema_workers_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CinemaWorkersPolicy < ApplicationPolicy
+  def create?
+    user&.role?(UserRoles::CINEMA_WORKER)
+  end
+end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationSerializer
+  include JSONAPI::Serializer
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UserSerializer < ApplicationSerializer
+  attributes :first_name, :last_name, :email
+end

--- a/app/validators/application_validator.rb
+++ b/app/validators/application_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ApplicationValidator < Dry::Validation::Contract
+  def validate(params)
+    validation_errors = call(params).errors.to_h
+    return if validation_errors.blank?
+
+    raise ValidationError, validation_errors
+  end
+end

--- a/app/validators/users/create_validator.rb
+++ b/app/validators/users/create_validator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Users
+  class CreateValidator < ApplicationValidator
+    params do
+      required(:first_name).filled(:string)
+      required(:last_name).filled(:string)
+      required(:email).filled(:string)
+      required(:password).filled(:string)
+      required(:password_confirmation).filled(:string)
+    end
+
+    rule(:email) do
+      key.failure('is already used') if User.exists?(email: value)
+    end
+
+    rule(:email) do
+      key.failure('has invalid format') unless Devise.email_regexp.match?(value)
+    end
+
+    rule(:password_confirmation, :password) do
+      key.failure('must match password') if values[:password] != values[:password_confirmation]
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,16 +1,7 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
-
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end

--- a/db/migrate/20210301222901_add_is_cinema_worker_to_users.rb
+++ b/db/migrate/20210301222901_add_is_cinema_worker_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsCinemaWorkerToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :is_cinema_worker, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_27_211625) do
+ActiveRecord::Schema.define(version: 2021_03_01_222901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2021_02_27_211625) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
+    t.boolean "is_cinema_worker", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/api/v1/cinema_workers/create_spec.rb
+++ b/spec/controllers/api/v1/cinema_workers/create_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe API::V1::CinemaWorkers::Create, type: :request do
+  subject(:call) { post endpoint, params: params, headers: auth_header(token) }
+
+  let(:endpoint) { '/api/v1/cinema_workers' }
+  let(:params) do
+    {
+      'first_name' => 'Test',
+      'last_name' => 'User',
+      'email' => 'test@example.com',
+      'password' => 'Password123',
+      'password_confirmation' => 'Password123'
+    }
+  end
+
+  context 'when not authenticated' do
+    let(:token) { nil }
+
+    it 'responds with 401 status' do
+      call
+      expect(response).to have_http_status(401)
+    end
+  end
+
+  context 'with authenticated user' do
+    include_context 'with authenticated user'
+
+    let(:current_user_email) { 'existing_user@example.com' }
+    let(:current_user_password) { 'Password123' }
+
+    before do
+      User.create!(email: current_user_email, password: current_user_password, is_cinema_worker: is_cinema_worker)
+    end
+
+    context 'when not authorized' do
+      let(:is_cinema_worker) { false }
+
+      it 'responds with 403 status' do
+        call
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when authorized' do
+      let(:is_cinema_worker) { true }
+      let(:new_user) { User.last }
+
+      let(:expected_response) do
+        {
+          'data' => {
+            'id' => new_user.id.to_s,
+            'type' => 'user',
+            'attributes' => {
+              'first_name' => 'Test',
+              'last_name' => 'User',
+              'email' => 'test@example.com'
+            }
+          }
+        }
+      end
+
+      it 'responds with 201 status' do
+        call
+        expect(response).to have_http_status(201)
+      end
+
+      it 'creates a new user' do
+        expect { call }.to change(User, :count).by(1)
+      end
+
+      it 'creates a new user with cinema worker permissions' do
+        call
+        expect(new_user.role?(UserRoles::CINEMA_WORKER)).to be_truthy
+      end
+
+      it 'creates a new user with given params' do
+        call
+        expect(new_user.attributes).to include(params.except('password', 'password_confirmation'))
+      end
+
+      it 'returns new user params serialized to JSON' do
+        call
+        expect(JSON.parse(response.body)).to match(expected_response)
+      end
+
+      context 'with invalid params' do
+        let(:params) do
+          {
+            first_name: 'Test',
+            last_name: 'User',
+            email: 'test@example.com',
+            password: 'Password123',
+            password_confirmation: 'Password'
+          }
+        end
+
+        it 'responds with 422 status' do
+          call
+          expect(response).to have_http_status(422)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/users/create_spec.rb
+++ b/spec/controllers/api/v1/users/create_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe API::V1::Users::Create, type: :request do
+  subject(:call) { post endpoint, params: params }
+
+  let(:endpoint) { '/api/v1/users' }
+  let(:params) do
+    {
+      'first_name' => 'Test',
+      'last_name' => 'User',
+      'email' => 'test@example.com',
+      'password' => 'Password123',
+      'password_confirmation' => 'Password123'
+    }
+  end
+
+  let(:new_user) { User.last }
+
+  let(:expected_response) do
+    {
+      'data' => {
+        'id' => new_user.id.to_s,
+        'type' => 'user',
+        'attributes' => {
+          'first_name' => 'Test',
+          'last_name' => 'User',
+          'email' => 'test@example.com'
+        }
+      }
+    }
+  end
+
+  it 'responds with 201 status' do
+    call
+    expect(response).to have_http_status(201)
+  end
+
+  it 'creates a new user' do
+    expect { call }.to change(User, :count).by(1)
+  end
+
+  it 'creates a new user without cinema worker permissions' do
+    call
+    expect(new_user.role?(UserRoles::CINEMA_WORKER)).to be_falsey
+  end
+
+  it 'creates a new user with given params' do
+    call
+    expect(new_user.attributes).to include(params.except('password', 'password_confirmation'))
+  end
+
+  it 'returns new user params serialized to JSON' do
+    call
+    expect(JSON.parse(response.body)).to match(expected_response)
+  end
+
+  context 'with invalid params' do
+    let(:params) do
+      {
+        first_name: 'Test',
+        last_name: 'User',
+        email: 'test@example.com',
+        password: 'Password123',
+        password_confirmation: 'Password'
+      }
+    end
+
+    it 'responds with 422 status' do
+      call
+      expect(response).to have_http_status(422)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ describe User, type: :model do
   describe '#role?' do
     subject(:call) { user.role?(role) }
 
-    let(:user) { User.create(is_cinema_worker: is_cinema_worker) }
+    let(:user) { User.create!(is_cinema_worker: is_cinema_worker) }
     let(:role) { UserRoles::CINEMA_WORKER }
 
     context 'when user has requested role' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe User, type: :model do
+  describe '#role?' do
+    subject(:call) { user.role?(role) }
+
+    let(:user) { User.create(is_cinema_worker: is_cinema_worker) }
+    let(:role) { UserRoles::CINEMA_WORKER }
+
+    context 'when user has requested role' do
+      let(:is_cinema_worker) { true }
+
+      it { expect(call).to be_truthy }
+    end
+
+    context 'when user does not have requested role' do
+      let(:is_cinema_worker) { false }
+
+      it { expect(call).to be_falsey }
+    end
+  end
+end

--- a/spec/policies/cinema_workers_policy_spec.rb
+++ b/spec/policies/cinema_workers_policy_spec.rb
@@ -8,7 +8,7 @@ describe CinemaWorkersPolicy, type: :policy do
   describe '#create?' do
     subject(:call) { policy.create? }
 
-    let(:user) { User.create(is_cinema_worker: is_cinema_worker) }
+    let(:user) { User.create!(is_cinema_worker: is_cinema_worker) }
     let(:resource) { User }
 
     context 'when given user is a cinema worker' do

--- a/spec/policies/cinema_workers_policy_spec.rb
+++ b/spec/policies/cinema_workers_policy_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CinemaWorkersPolicy, type: :policy do
+  subject(:policy) { described_class.new(user, resource) }
+
+  describe '#create?' do
+    subject(:call) { policy.create? }
+
+    let(:user) { User.create(is_cinema_worker: is_cinema_worker) }
+    let(:resource) { User }
+
+    context 'when given user is a cinema worker' do
+      let(:is_cinema_worker) { true }
+
+      it { expect(call).to be_truthy }
+    end
+
+    context 'when given user is not a cinema worker' do
+      let(:is_cinema_worker) { false }
+
+      it { expect(call).to be_falsey }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,3 +62,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include AuthHeaderHelper, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literaL: true
+
+require 'rails_helper'
+
+describe UserSerializer, type: :serializer do
+  subject(:serializer) { described_class.new(user) }
+
+  let(:user) do
+    User.create!(
+      first_name: first_name,
+      last_name: last_name,
+      email: email
+    )
+  end
+
+  let(:first_name) { 'Test' }
+  let(:last_name) { 'User' }
+  let(:email) { 'test@user.com' }
+
+  describe '#as_json' do
+    subject(:as_json) { serializer.as_json }
+
+    describe 'data' do
+      subject(:data) { as_json['data'] }
+
+      it 'contains correct type' do
+        expect(data['type']).to eq('user')
+      end
+
+      it 'contains correct id' do
+        expect(data['id']).to eq(user.id.to_s)
+      end
+
+      describe 'attributes' do
+        subject(:attributes) { data['attributes'] }
+
+        let(:expected_attributes) do
+          {
+            'first_name' => first_name,
+            'last_name' => last_name,
+            'email' => email
+          }
+        end
+
+        it 'contains episode attributes' do
+          expect(attributes).to eq(expected_attributes)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/helpers/auth_header_helper.rb
+++ b/spec/support/helpers/auth_header_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AuthHeaderHelper
+  def auth_header(token)
+    { 'Authorization' => "Bearer #{token}" }
+  end
+end

--- a/spec/support/shared_contexts/authenticated_user.rb
+++ b/spec/support/shared_contexts/authenticated_user.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+shared_context 'with authenticated user' do
+  let(:auth_params) do
+    {
+      user: {
+        email: current_user_email,
+        password: current_user_password
+      }
+    }
+  end
+
+  let(:token) do
+    post '/api/login', params: auth_params
+    response.headers['Authorization']&.delete_prefix('Bearer ')
+  end
+end

--- a/spec/support/shared_examples/validation_error.rb
+++ b/spec/support/shared_examples/validation_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+shared_examples 'failing validation' do
+  it 'raises a validation error' do
+    expect { validate }.to raise_error(ValidationError)
+  end
+end

--- a/spec/validators/users/create_validator_spec.rb
+++ b/spec/validators/users/create_validator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Users::CreateValidator, type: :validator do
+  subject(:validator) { described_class.new }
+
+  describe '#validate' do
+    subject(:validate) { validator.validate(params) }
+
+    let(:params) do
+      {
+        first_name: first_name,
+        last_name: last_name,
+        email: email,
+        password: password,
+        password_confirmation: password_confirmation
+      }
+    end
+
+    let(:first_name) { 'Test' }
+    let(:last_name) { 'User' }
+    let(:email) { 'test@example.com' }
+    let(:password) { 'Password123' }
+    let(:password_confirmation) { 'Password123' }
+
+    it 'does not raise any validation errors' do
+      expect { validate }.not_to raise_error
+    end
+
+    context 'with empty first name' do
+      let(:first_name) { '' }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with empty last name' do
+      let(:last_name) { '' }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with empty email' do
+      let(:email) { '' }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with used email' do
+      before { User.create(email: email) }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with invalid email format' do
+      let(:email) { 'invalid_email' }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with empty password' do
+      let(:password) { '' }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with empty password and password confirmation' do
+      let(:password) { '' }
+      let(:password_confirmation) { '' }
+
+      it_behaves_like 'failing validation'
+    end
+
+    context 'with password confirmation different than the password' do
+      let(:password_confirmation) { 'Asdf123' }
+
+      it_behaves_like 'failing validation'
+    end
+  end
+end

--- a/spec/validators/users/create_validator_spec.rb
+++ b/spec/validators/users/create_validator_spec.rb
@@ -47,7 +47,7 @@ describe Users::CreateValidator, type: :validator do
     end
 
     context 'with used email' do
-      before { User.create(email: email) }
+      before { User.create!(email: email) }
 
       it_behaves_like 'failing validation'
     end


### PR DESCRIPTION
- setup `pundit` to handle authorization
- setup `dry-validation` to handle inpur parameters validation
- setup auth helpers for `grape` to properly integrate with `devise`
- introduce rescuers to properly wrap application exceptions in HTTP errors
- setup `jsonapi-serializer` to handle objects to JSON serialization in a JSON API standard compliant way
- setup very simple roles system for user model
- add two registration endpoints: one for a regular user and one for a cinema worker
- register API V1 in the main API module
